### PR TITLE
fix ClusterImportProcessorTest cant run

### DIFF
--- a/ageiport-task/ageiport-task-server-model/src/main/java/com/alibaba/ageiport/task/server/model/CreateMainTaskInstanceRequest.java
+++ b/ageiport-task/ageiport-task-server-model/src/main/java/com/alibaba/ageiport/task/server/model/CreateMainTaskInstanceRequest.java
@@ -95,6 +95,11 @@ public class CreateMainTaskInstanceRequest extends Request<CreateMainTaskInstanc
      */
     private String runtimeParam;
 
+    /**
+     * 扩展字段，JSON格式
+     */
+    private String feature;
+
     public CreateMainTaskInstanceRequest() {
         System.out.println("1");
     }


### PR DESCRIPTION
ClusterImportProcessorTest导入的时候生成的文件key是通过Feature字段进行存储，HttpTaskServerClient中createMainTask的BeanUtils.cloneProp当中，由于CreateMainTaskInstanceRequest没有feature字段，所以导致存储当中没有key的存在，导致后续任务读取文件出现空指针。